### PR TITLE
Add return types to Doctrine types

### DIFF
--- a/src/Doctrine/Types/Math/BigDecimalType.php
+++ b/src/Doctrine/Types/Math/BigDecimalType.php
@@ -18,7 +18,7 @@ class BigDecimalType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'BigDecimal';
     }
@@ -26,13 +26,15 @@ class BigDecimalType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return $platform->getDecimalTypeDeclarationSQL($fieldDeclaration);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -45,6 +47,8 @@ class BigDecimalType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -62,7 +66,7 @@ class BigDecimalType extends Type
     /**
      * {@inheritdoc}
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }

--- a/src/Doctrine/Types/Math/BigIntegerType.php
+++ b/src/Doctrine/Types/Math/BigIntegerType.php
@@ -18,7 +18,7 @@ class BigIntegerType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'BigInteger';
     }
@@ -26,13 +26,15 @@ class BigIntegerType extends Type
     /**
      * {@inheritdoc}
      */
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return $platform->getDecimalTypeDeclarationSQL($fieldDeclaration);
     }
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
@@ -45,6 +47,8 @@ class BigIntegerType extends Type
 
     /**
      * {@inheritdoc}
+     *
+     * @return mixed
      */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
@@ -62,7 +66,7 @@ class BigIntegerType extends Type
     /**
      * {@inheritdoc}
      */
-    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
     }


### PR DESCRIPTION
```2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getName()" might add "string" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigDecimalType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getSQLDeclaration()" might add "string" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigDecimalType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToPHPValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigDecimalType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToDatabaseValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigDecimalType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::requiresSQLCommentHint()" might add "bool" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigDecimalType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getName()" might add "string" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigIntegerType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::getSQLDeclaration()" might add "string" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigIntegerType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToPHPValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigIntegerType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::convertToDatabaseValue()" might add "mixed" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigIntegerType" now to avoid errors or add an explicit @return annotation to suppress this message.
2022-03-09T09:08:25+00:00 [info] User Deprecated: Method "Doctrine\DBAL\Types\Type::requiresSQLCommentHint()" might add "bool" as a native return type declaration in the future. Do the same in child class "Brick\Doctrine\Types\Math\BigIntegerType" now to avoid errors or add an explicit @return annotation to suppress this message.```